### PR TITLE
Implemented get current focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+jelly

--- a/Sources/Open-Jellycore/Core/Compiler/Lookup Tables/Apps/Shortcuts/Actions/GetCurrentFocusParameter.swift
+++ b/Sources/Open-Jellycore/Core/Compiler/Lookup Tables/Apps/Shortcuts/Actions/GetCurrentFocusParameter.swift
@@ -1,0 +1,20 @@
+//
+//  GetCurrentFocusParameter.swift
+//  Open-Jellycore
+//
+//  Created by Albion Fung on 5 Dec 2023.
+//
+
+struct GetCurrentFocusParameter: ParameterProtocol, Codable {
+
+
+    static func build(call: [FunctionCallParameterItem], scopedVariables: [Variable]) -> ParameterProtocol {
+        return GetCurrentFocusParameter()
+    }
+     
+    static func getDefaultValues() -> [String: String] {
+        return [
+:
+        ]
+    }
+}

--- a/Sources/Open-Jellycore/Core/Compiler/Lookup Tables/Apps/Shortcuts/ShortcutsLookupTable.swift
+++ b/Sources/Open-Jellycore/Core/Compiler/Lookup Tables/Apps/Shortcuts/ShortcutsLookupTable.swift
@@ -1473,6 +1473,11 @@ ActionPreset(path: "WFEncodeMode", value: "Encode"),
                                 """, lowestCompatibleHost: .iOS14, presets: [
                                     
                                 ]),
+   "getCurrentFocus": Action<GetCurrentFocusParameter>(name:"Get current focus", identifier: "is.workflow.actions.dnd.getfocus", correctTypedFunction: "getCurrentFocus", description: """
+                                Get the current focus active.
+                                """, lowestCompatibleHost: .iOS16, presets: [
+
+                                ])
 
     ]
 }


### PR DESCRIPTION
Added the `getCurrentFocus` function to the `Shortcuts` builtin library. This function is available from iOS16.1 and above. Tested by writing a jelly script calling above function, and ensuring on a Mac and iPhone that the resulting shortcut behaves as expected.

Also added `jelly` to `.gitignore` to make testing life just a little bit easier; can remove if you believe this is unwise for it to be in the same commit.